### PR TITLE
Fix: GitHub Actions Swift Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -18,10 +18,10 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "SwiftSafeUI"
+            name: "SwiftSafeUI",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]
         ),
-    ],
-    swiftLanguageModes: [
-        .v5, .v6
     ]
 )


### PR DESCRIPTION
### What this MR does:
* Support Swift version `5.10` instead of `6.0`
* Enable complete strict concurrency in Swift code